### PR TITLE
Updated Nokogiri & spec to suppress deprecation warnings

### DIFF
--- a/jobviter.gemspec
+++ b/jobviter.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.add_dependency 'typhoeus', ['~> 0.2.4']
-  s.add_dependency 'nokogiri', ['~> 1.4.6']
+  s.add_dependency 'nokogiri', ['~> 1.5.6']
 
-  # Developmnet Dependencies
+  # Development Dependencies
   s.add_development_dependency 'rspec', ['~> 2.6']
   s.add_development_dependency 'mocha', ['~> 0.9.12']
+  s.add_development_dependency 'rake',  ['~> 10.0.3']
 end

--- a/spec/jobviter/config_spec.rb
+++ b/spec/jobviter/config_spec.rb
@@ -33,7 +33,7 @@ describe Jobviter::Config do
 
       expect do
         Jobviter.config.jobs_url
-      end.should raise_exception(Jobviter::Exception::InvalidConfiguration)
+      end.to raise_exception(Jobviter::Exception::InvalidConfiguration)
     end
   end
 

--- a/spec/jobviter/job_spec.rb
+++ b/spec/jobviter/job_spec.rb
@@ -71,7 +71,7 @@ describe Jobviter::Job do
 
       expect do
         Jobviter::Job.all
-      end.should raise_exception(Jobviter::Exception::BadResponse)
+      end.to raise_exception(Jobviter::Exception::BadResponse)
     end
   end
 


### PR DESCRIPTION
I am using this with a MiddleMan based static site generator that uses a newer version of Nokogiri for other tasks.

I bumped the version of Nokogiri, specified a specific rake version, and fixe the deprecation warnings on the spec tests so it would integrate properly.
