### PR TITLE
Fix README: Twitter no longer uses Jobvite

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,21 @@ Installation instructions are given on their respective sites.
 Usage
 -----
 
-Below is an example of using Jobviter to pull down a list of Twitter
+Below is an example of using Jobviter to pull down a list of TiVo
 job listings.
 
     ruby > require 'jobviter'
     ruby > Jobviter.configure do |config|
-    ruby >   config.company_id = 'q8X9VfwT'
+    ruby >   config.company_id = 'q1h9Vfw6'
     ruby > end
     ruby > jobs = Jobviter::Job.all
      => 71
     ruby > job = jobs.first
      => #<Jobviter::Job:0x00000100a85600>
     ruby > job.title
-     => "Software Engineer - Tools"
+     => "Sr. Supervisor"
     ruby > job.apply_url
-     => "http://hire.jobvite.com/CompanyJobs/Apply.aspx?c=q8X9VfwT&j=oSbdVfwV"
+     => "http://app.jobvite.com/CompanyJobs/Careers.aspx?c=q1h9Vfw6&j=obuW5fwq&k=Apply"
 
 
 Contributing


### PR DESCRIPTION
Thanks for this repository!

I tried the example from the README and it was failing due to the fact that Twitter no longer employs Jobvite for job applications ([example](https://careers.twitter.com/en/work-for-twitter/201710/engineering-manager-consumer-product.html)).

I replaced the company ID of Twitter with another company that is [still active on Jobvite](http://jobs.jobvite.com/careers/tivo) (TiVo) and the code worked flawlessly. 🎉 